### PR TITLE
Update ExternalCommandReceiver.java

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,11 @@ led | tracking | synchronization
   - target package: `net.fabiszewski.ulogger`
   - target class: `net.fabiszewski.ulogger.ExternalCommandReceiver`
   - action: `net.fabiszewski.ulogger.intent.action.COMMAND`
-  - extra: `"command": [command name]`, where command name is one of: `"start logger"`, `"stop logger"`, `"start upload"`, for starting and stopping position logging and starting track data upload to server (in case live tracking is off)
+  - extra: `"command": [command name]`, where command name is one of: 
+    - `"start logger"` for starting position logging
+    - `"start new logger"` for creating a New Track and starting position logging to it 
+    - `"stop logger"` for stopping position logging
+    - `"start upload"` for starting track data upload to server (in case live tracking is off)
 - third party examples:
   - Automate (LlamaLab) – Send broadcast block with `Package`, `Receiver Class` and `Action` fields as above and `Extras` field eg. `{"command": "start logger"}`
   - Tasker (joaomgcd) – System → Send intent. Fields `Action`, `Package`, `Class` as above and `Extra` field eg. `command:start logger`

--- a/app/src/main/java/net/fabiszewski/ulogger/ExternalCommandReceiver.java
+++ b/app/src/main/java/net/fabiszewski/ulogger/ExternalCommandReceiver.java
@@ -20,6 +20,7 @@ import androidx.preference.PreferenceManager;
 public class ExternalCommandReceiver extends BroadcastReceiver {
 
     private static final String START_LOGGER = "start logger";
+    private static final String START_NEW_LOGGER = "start new logger";
     private static final String STOP_LOGGER = "stop logger";
     private static final String START_UPLOAD = "start upload";
 
@@ -37,6 +38,9 @@ public class ExternalCommandReceiver extends BroadcastReceiver {
                     case START_LOGGER:
                         startLoggerService(context);
                         break;
+                    case START_NEW_LOGGER:
+                        startNewLoggerService(context);
+                        break;
                     case STOP_LOGGER:
                         stopLogger(context);
                         break;
@@ -49,6 +53,20 @@ public class ExternalCommandReceiver extends BroadcastReceiver {
 
     }
 
+
+    /**
+     * Start logger service (new trace)
+     * @param context Context
+     */
+    private void startNewLoggerService(Context context) {
+        DbAccess db = DbAccess.getInstance();
+        db.open(context);
+        db.newTrack(AutoNamePreference.getAutoTrackName(context));
+
+        db.close();
+        Intent intent = new Intent(context, LoggerService.class);
+        ContextCompat.startForegroundService(context, intent);
+    }
 
     /**
      * Start logger service


### PR DESCRIPTION
Added an additional external command "start new logger", which will forcefully create a new track before starting the logging.
As can be seen, I simply duplicated the normal "start logger" and forced the creation of a new track by removing the conditional. I found this useful as Llama can now start a new track every day, automatically.