### PR TITLE
Send battery percentage with GPS data

### DIFF
--- a/app/src/main/java/net/fabiszewski/ulogger/services/WebSyncService.java
+++ b/app/src/main/java/net/fabiszewski/ulogger/services/WebSyncService.java
@@ -41,6 +41,7 @@ import net.fabiszewski.ulogger.db.DbContract;
 import net.fabiszewski.ulogger.utils.BroadcastHelper;
 import net.fabiszewski.ulogger.utils.NotificationHelper;
 import net.fabiszewski.ulogger.utils.WebHelper;
+import net.fabiszewski.ulogger.utils.BatteryUtil;
 
 import org.json.JSONException;
 
@@ -351,6 +352,13 @@ public class WebSyncService extends Service {
         if (DbAccess.hasImageUri(cursor)) {
             params.put(WebHelper.PARAM_IMAGE, DbAccess.getImageUri(cursor));
         }
+
+        // Read battery percent only at send-time and add it if available (0..100)
+        int battery = BatteryUtil.getBatteryPercent(getApplicationContext());
+        if (battery >= 0) {
+            params.put(WebHelper.PARAM_BATTERY, String.valueOf(battery));
+        }
+
         return params;
     }
 

--- a/app/src/main/java/net/fabiszewski/ulogger/utils/BatteryUtil.java
+++ b/app/src/main/java/net/fabiszewski/ulogger/utils/BatteryUtil.java
@@ -1,0 +1,50 @@
+/*
+ * eirmd
+ * This file is part of μlogger-android.
+ * Licensed under GPL, either version 3, or any later.
+ * See <http://www.gnu.org/licenses/>
+ */
+
+package net.fabiszewski.ulogger.utils;
+
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.os.BatteryManager;
+
+/**
+ * Small helper to read the current battery percentage without requiring extra permissions.
+ * Returns 0..100 on success, or -1 if the value cannot be determined.
+ */
+public final class BatteryUtil {
+
+    private BatteryUtil() { /* no instances */ }
+
+    /**
+     * Returns battery percent (0..100) or -1 if unknown.
+     * Use applicationContext where possible to avoid leaking Activities.
+     */
+    public static int getBatteryPercent(Context context) {
+        if (context == null) return -1;
+
+        // Preferred API (fast, no permission)
+        BatteryManager bm = (BatteryManager) context.getSystemService(Context.BATTERY_SERVICE);
+        if (bm != null) {
+            int pct = bm.getIntProperty(BatteryManager.BATTERY_PROPERTY_CAPACITY);
+            if (pct >= 0) return pct;
+        }
+
+        // Fallback: sticky ACTION_BATTERY_CHANGED intent
+        IntentFilter iFilter = new IntentFilter(Intent.ACTION_BATTERY_CHANGED);
+        Intent batteryStatus = context.registerReceiver(null, iFilter);
+        if (batteryStatus != null) {
+            int level = batteryStatus.getIntExtra(BatteryManager.EXTRA_LEVEL, -1);
+            int scale = batteryStatus.getIntExtra(BatteryManager.EXTRA_SCALE, -1);
+            if (level >= 0 && scale > 0) {
+                return (int) ((level / (float) scale) * 100);
+            }
+        }
+
+        return -1;
+    }
+}

--- a/app/src/main/java/net/fabiszewski/ulogger/utils/WebHelper.java
+++ b/app/src/main/java/net/fabiszewski/ulogger/utils/WebHelper.java
@@ -95,6 +95,8 @@ public class WebHelper {
     public static final String PARAM_PROVIDER = "provider";
     public static final String PARAM_COMMENT = "comment";
     public static final String PARAM_IMAGE = "image";
+    // New: battery percent parameter
+    public static final String PARAM_BATTERY = "battery";
     public static final String PARAM_TRACKID = "trackid";
 
     // auth


### PR DESCRIPTION
This PR adds the ability for the Android app to include the device battery percentage with each GPS/location update sent to the server.

- Adds BatteryUtil.java to read battery percent (0–100)
- Includes battery value in the position payload
- No extra permissions are required
- Backward compatible: works with older server versions (battery ignored) and older apps (battery stored as NULL)
